### PR TITLE
fixed role name

### DIFF
--- a/packer-image/requirements.yml
+++ b/packer-image/requirements.yml
@@ -1,4 +1,4 @@
-- src: geerlingguy.ansible-role-packer
+- src: geerlingguy.packer
   version: "1.0.1"
   name: packer
 


### PR DESCRIPTION
## BUG 😦 
```
==> amazon-ebs: Running local shell script: /var/folders/nf/k9pcy49104l7f_53fxgxs0dhnt96sl/T/packer-shell408318989
    amazon-ebs: - downloading role 'ansible-role-packer', owned by geerlingguy
==> amazon-ebs:  [WARNING]: - packer was NOT installed successfully: - sorry,
==> amazon-ebs: geerlingguy.ansible-role-packer was not found on https://galaxy.ansible.com.
==> amazon-ebs: 
==> amazon-ebs: ERROR! - you can use --ignore-errors to skip failed roles and finish processing the list.
==> amazon-ebs: Terminating the source AWS instance...
==> amazon-ebs: Cleaning up any extra volumes...
==> amazon-ebs: No volumes to clean up, skipping
==> amazon-ebs: Deleting temporary security group...
==> amazon-ebs: Deleting temporary keypair...
Build 'amazon-ebs' errored: Erroneous exit code 1 while executing script: /var/folders/nf/k9pcy49104l7f_53fxgxs0dhnt96sl/T/packer-shell408318989
```

## Reason
The name of this role changed -> https://github.com/geerlingguy/ansible-role-packer

## FIXED!
`packer build packer.json` runs successfully 