### PR TITLE
[wip] add vagrant image for amazon linux 2 for testing 

### DIFF
--- a/cis/packer.json
+++ b/cis/packer.json
@@ -2,9 +2,9 @@
   "variables": {
     "region": "us-east-1",
     "instance_type": "t3.medium",
-    "associate_public_ip": "true",
-    "vpc": "",
-    "subnet": ""
+    "associate_public_ip": "false",
+    "vpc": "vpc-1f48027a",
+    "subnet": "subnet-02834974"
   },
   "builders": [
     {
@@ -104,6 +104,14 @@
         "Name": "packer_amazon_2_cis {{timestamp}}",
         "build_time": "{{timestamp}}"
       }
+    },
+    {
+      "name" :"amazon2-cis-amazon-vagrant",
+      "type": "vagrant",
+      "source_path": "bento/amazonlinux-2",
+      "provider": "virtualbox",
+      "add_force": true,
+      "communicator": "ssh"
     }
   ],
   "provisioners": [
@@ -137,7 +145,8 @@
         "sudo yum install -y python python3 python-pip python3-pip"
       ],
       "only": [
-        "amazon2-cis-amazon-ebs"
+        "amazon2-cis-amazon-ebs",
+        "amazon2-cis-amazon-vagrant"
       ]
     },
     {

--- a/cis/packer.json
+++ b/cis/packer.json
@@ -2,7 +2,7 @@
   "variables": {
     "region": "us-east-1",
     "instance_type": "t3.medium",
-    "associate_public_ip": "false",
+    "associate_public_ip": "true",
     "vpc": "vpc-1f48027a",
     "subnet": "subnet-02834974"
   },


### PR DESCRIPTION
I thought I'd draw your guys' attention to this because I think it's worthwhile. Right now I'm using this image pulled from Vagrant's cloud https://app.vagrantup.com/bento/boxes/amazonlinux-2 / https://github.com/chef/bento/blob/master/packer_templates/amazonlinux/amazon-2-x86_64.json 